### PR TITLE
first templates for Model Generation

### DIFF
--- a/hydro_model_builder/__init__.py
+++ b/hydro_model_builder/__init__.py
@@ -5,3 +5,6 @@
 __author__ = """Gennadii Donchyts"""
 __email__ = 'gennadiy.donchyts@gmail.com'
 __version__ = '0.1.0'
+
+__all__ = ["ModelGenerators"]
+

--- a/hydro_model_builder/hydro_model_builder.py
+++ b/hydro_model_builder/hydro_model_builder.py
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Main module."""
+
+import model_generators as mg
+

--- a/hydro_model_builder/model_generators/model_generator.py
+++ b/hydro_model_builder/model_generators/model_generator.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import json
+import geojson
+
+class model_generator(object):
+    def __init__(self, region_fn, options_fn):
+        self.region_fn = region_fn
+        self.options_fn = options_fn
+
+    def parse_config(self):
+        self.options = json.loads(self.option_fn)
+
+    def parse_location(self):
+        self.location = geojson.loads(self.region_fn)
+
+    def __init__(self, ):

--- a/hydro_model_builder/model_generators/wflow_model_generator.py
+++ b/hydro_model_builder/model_generators/wflow_model_generator.py
@@ -1,0 +1,29 @@
+import os
+from model_generator import *
+
+class wflow_model_generator(model_generator):
+
+    def __init__(self):
+        """
+        Add a template path to a model object
+
+        :return:
+        """
+        # TODO Think about how to retrieve a path for the template. Hard coded?
+        self.template_path = '.'
+        # TODO Retrieve template config.ini for an options specified one
+        self.template_config = os.path.join(self.template_path, 'config.ini')
+
+    def generate_model_files(self):
+        """
+        Convert all files into a model
+
+        :return:
+        """
+
+    def generate_config_files(self):
+        """
+        Generate one or multiple configuration or setting files for the model
+
+        :return:
+        """


### PR DESCRIPTION
Gena,

Tried to make a setup for the Model Generation scripts. Thought of the following:

There's a master model_generator class, that always collects info from the model-builder call (CLI or other), and always parses the user defined command line inputs. This class is then inherited by model-specific classes that consequently collect all the information through hydro-earth (model-intelligent) and prepare the required input layers in a given template and required config files for the specific model from template config files.

Could you review?